### PR TITLE
Remove pub from wgsl functions

### DIFF
--- a/bevy_gpu_compute_macro/src/transformer/to_wgsl_syntax/remove_pub_from_struct_def.rs
+++ b/bevy_gpu_compute_macro/src/transformer/to_wgsl_syntax/remove_pub_from_struct_def.rs
@@ -3,6 +3,11 @@ use syn::{Field, Visibility, visit_mut::VisitMut};
 pub struct PubRemover {}
 
 impl VisitMut for PubRemover {
+    fn visit_item_fn_mut(&mut self, i: &mut syn::ItemFn) {
+        syn::visit_mut::visit_item_fn_mut(self, i);
+        i.vis = Visibility::Inherited;
+    }
+
     fn visit_field_mut(&mut self, i: &mut Field) {
         syn::visit_mut::visit_field_mut(self, i);
         i.vis = Visibility::Inherited;


### PR DESCRIPTION
Just a simple fix for 'pub' ending up in parsed shaders from functions.