### PR TITLE
Restore cpu module visibility

### DIFF
--- a/bevy_gpu_compute_macro/src/transformer/output/module_for_cpu/lib.rs
+++ b/bevy_gpu_compute_macro/src/transformer/output/module_for_cpu/lib.rs
@@ -10,6 +10,7 @@ pub fn generate_module_for_cpu_usage(state: &ModuleTransformState) -> TokenStrea
     let main_func = generate_main_func(state);
     let consts = generate_module_level_consts(state);
     quote!(
+        pub use on_cpu::*;
         pub mod on_cpu {
             use super::*;
             use bevy_gpu_compute_core::wgsl_helpers::*;

--- a/bevy_gpu_compute_macro/tests/components.rs
+++ b/bevy_gpu_compute_macro/tests/components.rs
@@ -654,7 +654,7 @@ fn test_functions_exposed_for_rust() {
     }
 
     // you can now use any helper functions in the module like this:
-    let f1_test = example_shader_module::on_cpu::calculate_distance_squared([1.0, 2.0], [3.0, 4.0]);
+    let f1_test = example_shader_module::calculate_distance_squared([1.0, 2.0], [3.0, 4.0]);
     assert_eq!(f1_test, 8.0);
 
     //* The main function is designed to mutate GPU buffers in WGSL, so we have to replicate this for a cpu version by requiring those same inputs to be passed as parameters to the main function */


### PR DESCRIPTION
This change makes it so you can refer to CPU helper functions as you would normally from a standard rust module.

e.g.
```rust
my_shader_module::on_cpu::my_helper()
```
becomes
```rust
my_shader_module::my_helper()
```

There are still some oddities, namely that currently user types are reexported by the parser instead of marking them `pub` like one would normally do in a standard rust module. I may address this in a future patch.