### PR TITLE
Upgrade to Bevy 0.18

### DIFF
--- a/bevy_gpu_compute/Cargo.toml
+++ b/bevy_gpu_compute/Cargo.toml
@@ -17,10 +17,10 @@ exclude = [
 [dependencies]
 bevy_gpu_compute_macro = { path = "../bevy_gpu_compute_macro", version = "0.1"}
 bevy_gpu_compute_core = { path = "../bevy_gpu_compute_core", version = "0.1"}
-bevy = "0.15"
+bevy = "0.18.1"
 futures = "0.3.31"
 pollster = "0.4.0"
-wgpu = "23.0.1"
+wgpu = "27"
 sysinfo = "0.33.0"
 bytemuck = {version = "1.21.0", features=["derive"]}
 

--- a/bevy_gpu_compute/examples/collision_detection_barebones/main.rs
+++ b/bevy_gpu_compute/examples/collision_detection_barebones/main.rs
@@ -4,8 +4,9 @@ Demonstrates only the features from BevyGpuCompute necessary for collision detec
 use bevy::{
     DefaultPlugins,
     app::{App, AppExit, Startup, Update},
+    ecs::message::MessageWriter,
     log,
-    prelude::{EventWriter, IntoSystemConfigs, Local, Query, Res, ResMut, Resource},
+    prelude::{IntoScheduleConfigs, Local, Query, Res, ResMut, Resource},
 };
 use bevy_gpu_compute::prelude::*;
 mod visuals;
@@ -152,12 +153,16 @@ fn handle_task_results(mut gpu_task_reader: GpuTaskReader, mut state: ResMut<Sta
 }
 
 // when the local variable "count" goes above a certain number (representing frame count), exit the app
-fn exit_and_show_results(mut count: Local<u32>, state: Res<State>, mut exit: EventWriter<AppExit>) {
+fn exit_and_show_results(
+    mut count: Local<u32>,
+    state: Res<State>,
+    mut exit: MessageWriter<AppExit>,
+) {
     if *count > EXIT_AFTER_FRAMES {
         let total_collisions = state.collisions_per_frame.iter().sum::<usize>();
         log::trace!("total collisions count at exit: {}", total_collisions);
         log::info!("Example completed successfully");
-        exit.send(AppExit::Success);
+        exit.write(AppExit::Success);
     }
     *count += 1;
 }

--- a/bevy_gpu_compute/examples/collision_detection_barebones/main.rs
+++ b/bevy_gpu_compute/examples/collision_detection_barebones/main.rs
@@ -4,9 +4,8 @@ Demonstrates only the features from BevyGpuCompute necessary for collision detec
 use bevy::{
     DefaultPlugins,
     app::{App, AppExit, Startup, Update},
-    ecs::message::MessageWriter,
     log,
-    prelude::{IntoScheduleConfigs, Local, Query, Res, ResMut, Resource},
+    prelude::{IntoScheduleConfigs, MessageWriter, Local, Query, Res, ResMut, Resource},
 };
 use bevy_gpu_compute::prelude::*;
 mod visuals;

--- a/bevy_gpu_compute/examples/collision_detection_barebones/visuals.rs
+++ b/bevy_gpu_compute/examples/collision_detection_barebones/visuals.rs
@@ -1,15 +1,17 @@
 use bevy::{
     asset::Handle,
+    camera::Projection,
     log,
-    prelude::{Color, Component, FromWorld, Resource, World},
-    sprite::ColorMaterial,
-    utils::hashbrown::HashMap,
+    platform::collections::HashMap,
+    prelude::{Color, ColorMaterial, Component, FromWorld, Resource, World},
 };
 use bevy::{
     asset::{Assets, RenderAssetUsages},
     math::{Vec2, Vec3, bounding::BoundingCircle},
-    prelude::{Camera2d, Commands, Mesh, Mesh2d, OrthographicProjection, Res, ResMut, Transform},
-    sprite::MeshMaterial2d,
+    prelude::{
+        Camera2d, Commands, Mesh, Mesh2d, MeshMaterial2d, OrthographicProjection, Res, ResMut,
+        Transform,
+    },
     utils::default,
 };
 
@@ -53,12 +55,12 @@ pub fn spawn_entities(
 pub fn spawn_camera(mut commands: Commands) {
     commands.spawn((
         Camera2d,
-        OrthographicProjection {
+        Projection::Orthographic(OrthographicProjection {
             near: -1000.0,
             far: 1000.0,
             scale: 0.1,
             ..OrthographicProjection::default_2d()
-        },
+        }),
         Transform::from_xyz(
             0., 0., 10.0, // 100.0,
         ),

--- a/bevy_gpu_compute/examples/collision_detection_demonstration/main.rs
+++ b/bevy_gpu_compute/examples/collision_detection_demonstration/main.rs
@@ -5,8 +5,9 @@ Demonstrates all features of the BevyGpuCompute library
 use bevy::{
     DefaultPlugins,
     app::{App, AppExit, PluginGroup, Startup, Update},
+    ecs::message::MessageWriter,
     log::{self, LogPlugin},
-    prelude::{EventWriter, IntoSystemConfigs, Local, Query, Res, ResMut, Resource},
+    prelude::{IntoScheduleConfigs, Local, Query, Res, ResMut, Resource},
 };
 use bevy_gpu_compute::prelude::*;
 mod visuals;
@@ -230,7 +231,11 @@ fn handle_task_results(mut gpu_task_reader: GpuTaskReader, mut state: ResMut<Sta
 }
 
 // when the local variable "count" goes above a certain number (representing frame count), exit the app
-fn exit_and_show_results(mut count: Local<u32>, state: Res<State>, mut exit: EventWriter<AppExit>) {
+fn exit_and_show_results(
+    mut count: Local<u32>,
+    state: Res<State>,
+    mut exit: MessageWriter<AppExit>,
+) {
     if *count > EXIT_AFTER_FRAMES {
         let total_collisions = state.collisions_per_frame.iter().sum::<usize>();
         log::trace!("total collisions count at exit: {}", total_collisions);
@@ -251,7 +256,7 @@ fn exit_and_show_results(mut count: Local<u32>, state: Res<State>, mut exit: Eve
             state.collisions_per_frame[2]
         );
         log::info!("Example completed successfully");
-        exit.send(AppExit::Success);
+        exit.write(AppExit::Success);
     }
     *count += 1;
 }

--- a/bevy_gpu_compute/examples/collision_detection_demonstration/main.rs
+++ b/bevy_gpu_compute/examples/collision_detection_demonstration/main.rs
@@ -5,9 +5,8 @@ Demonstrates all features of the BevyGpuCompute library
 use bevy::{
     DefaultPlugins,
     app::{App, AppExit, PluginGroup, Startup, Update},
-    ecs::message::MessageWriter,
     log::{self, LogPlugin},
-    prelude::{IntoScheduleConfigs, Local, Query, Res, ResMut, Resource},
+    prelude::{IntoScheduleConfigs, MessageWriter, Local, Query, Res, ResMut, Resource},
 };
 use bevy_gpu_compute::prelude::*;
 mod visuals;

--- a/bevy_gpu_compute/examples/collision_detection_demonstration/visuals.rs
+++ b/bevy_gpu_compute/examples/collision_detection_demonstration/visuals.rs
@@ -1,15 +1,17 @@
 use bevy::{
     asset::Handle,
+    camera::Projection,
     log,
-    prelude::{Color, Component, FromWorld, Resource, World},
-    sprite::ColorMaterial,
-    utils::hashbrown::HashMap,
+    platform::collections::HashMap,
+    prelude::{Color, ColorMaterial, Component, FromWorld, Resource, World},
 };
 use bevy::{
     asset::{Assets, RenderAssetUsages},
     math::{Vec2, Vec3, bounding::BoundingCircle},
-    prelude::{Camera2d, Commands, Mesh, Mesh2d, OrthographicProjection, Res, ResMut, Transform},
-    sprite::MeshMaterial2d,
+    prelude::{
+        Camera2d, Commands, Mesh, Mesh2d, MeshMaterial2d, OrthographicProjection, Res, ResMut,
+        Transform,
+    },
     utils::default,
 };
 
@@ -53,12 +55,12 @@ pub fn spawn_entities(
 pub fn spawn_camera(mut commands: Commands) {
     commands.spawn((
         Camera2d,
-        OrthographicProjection {
+        Projection::Orthographic(OrthographicProjection {
             near: -1000.0,
             far: 1000.0,
             scale: 0.1,
             ..OrthographicProjection::default_2d()
-        },
+        }),
         Transform::from_xyz(
             0., 0., 10.0, // 100.0,
         ),

--- a/bevy_gpu_compute/src/plugin.rs
+++ b/bevy_gpu_compute/src/plugin.rs
@@ -1,6 +1,6 @@
 use bevy::{
     app::{App, Plugin, Startup, Update},
-    prelude::{AppExtStates, IntoSystemConfigs, States, in_state},
+    prelude::{AppExtStates, IntoScheduleConfigs, States, in_state},
 };
 
 use crate::{

--- a/bevy_gpu_compute/src/spawn_fallback_camera.rs
+++ b/bevy_gpu_compute/src/spawn_fallback_camera.rs
@@ -1,8 +1,9 @@
 use bevy::{
+    camera::Projection,
     log,
     prelude::{
-        Camera, Camera2d, Commands, Component, DespawnRecursiveExt, Entity, OrthographicProjection,
-        Query, Res, Transform,
+        Camera, Camera2d, Commands, Component, Entity, OrthographicProjection, Query, Res,
+        Transform,
     },
     time::Time,
 };
@@ -26,12 +27,12 @@ pub fn spawn_fallback_camera(
             );
             commands.spawn((
                 Camera2d,
-                OrthographicProjection {
+                Projection::Orthographic(OrthographicProjection {
                     near: -10.0,
                     far: 10.0,
                     scale: 1.,
                     ..OrthographicProjection::default_2d()
-                },
+                }),
                 Transform::from_xyz(
                     0., 0., 10.0, // 100.0,
                 ),
@@ -46,7 +47,7 @@ pub fn spawn_fallback_camera(
             let fallback_cam_len = fallback_cameras.iter().len();
             if fallback_cam_len > 0 {
                 fallback_cameras.iter().for_each(|(e, _)| {
-                    commands.entity(e).despawn_recursive();
+                    commands.entity(e).despawn();
                 });
             }
         }

--- a/bevy_gpu_compute/src/system_params/task_deleter.rs
+++ b/bevy_gpu_compute/src/system_params/task_deleter.rs
@@ -1,6 +1,6 @@
 use bevy::{
     ecs::system::SystemParam,
-    prelude::{Commands, DespawnRecursiveExt, Entity, Query},
+    prelude::{Commands, Entity, Query},
 };
 
 use crate::task::lib::BevyGpuComputeTask;
@@ -20,6 +20,6 @@ impl BevyGpuComputeTaskDeleter<'_, '_> {
             .iter_mut()
             .find(|(_, task)| task.name() == name)
             .expect("Task not found");
-        self.commands.entity(entity).despawn_recursive();
+        self.commands.entity(entity).despawn();
     }
 }

--- a/bevy_gpu_compute/src/task/compute_pipeline/update_on_pipeline_const_change.rs
+++ b/bevy_gpu_compute/src/task/compute_pipeline/update_on_pipeline_const_change.rs
@@ -26,6 +26,13 @@ pub fn update_compute_pipeline(task: &mut BevyGpuComputeTask, render_device: &Re
             "pipeline layout {:?}",
             task.runtime_state().pipeline_layout()
         );
+
+        let pipeline_consts = task.get_pipeline_consts();
+        let constants_vec: Vec<(&str, f64)> = pipeline_consts
+            .iter()
+            .map(|(k, v)| (k.as_str(), *v))
+            .collect();
+
         let compute_pipeline = render_device.create_compute_pipeline(&ComputePipelineDescriptor {
             label: Some(task.name()),
             layout: Some(task.runtime_state().pipeline_layout()),
@@ -33,7 +40,7 @@ pub fn update_compute_pipeline(task: &mut BevyGpuComputeTask, render_device: &Re
             entry_point: Some(task.configuration().shader().entry_point_function_name()),
             // this is where we specify new values for pipeline constants...
             compilation_options: PipelineCompilationOptions {
-                constants: &task.get_pipeline_consts(),
+                constants: &constants_vec,
                 zero_initialize_workgroup_memory: Default::default(),
             },
             cache: None,

--- a/bevy_gpu_compute/src/task/lib.rs
+++ b/bevy_gpu_compute/src/task/lib.rs
@@ -82,6 +82,7 @@ impl BevyGpuComputeTask {
             render_device,
             iteration_space,
             max_output_vector_lengths,
+            // SAFETY: wgsl_shader_module is compiled and validated
             unsafe {
                 WgslCode::from_string(
                     name,

--- a/bevy_gpu_compute/src/task/lib.rs
+++ b/bevy_gpu_compute/src/task/lib.rs
@@ -82,12 +82,14 @@ impl BevyGpuComputeTask {
             render_device,
             iteration_space,
             max_output_vector_lengths,
-            WgslCode::from_string(
-                name,
-                render_device,
-                full_module.wgsl_code(iteration_space.num_dimmensions()),
-                "main".to_string(),
-            ),
+            unsafe {
+                WgslCode::from_string(
+                    name,
+                    render_device,
+                    full_module.wgsl_code(iteration_space.num_dimmensions()),
+                    "main".to_string(),
+                )
+            },
         )
     }
 

--- a/bevy_gpu_compute/src/task/outputs/helpers/get_gpu_output_as_bytes_vec.rs
+++ b/bevy_gpu_compute/src/task/outputs/helpers/get_gpu_output_as_bytes_vec.rs
@@ -18,7 +18,7 @@ pub fn get_gpu_output_as_bytes_vec(
     slice.map_async(wgpu::MapMode::Read, move |result| {
         sender.send(result).unwrap();
     });
-    render_device.poll(wgpu::Maintain::Wait);
+    let _ = render_device.poll(wgpu::PollType::wait_indefinitely());
 
     let result: Option<Vec<u8>> = if receiver.block_on().unwrap().is_ok() {
         let data = slice.get_mapped_range();

--- a/bevy_gpu_compute/src/task/outputs/helpers/get_gpu_output_counter_value.rs
+++ b/bevy_gpu_compute/src/task/outputs/helpers/get_gpu_output_counter_value.rs
@@ -24,7 +24,7 @@ pub fn get_gpu_output_counter_value(
     slice.map_async(wgpu::MapMode::Read, move |result| {
         sender.send(result).unwrap();
     });
-    render_device.poll(wgpu::Maintain::Wait);
+    let _ = render_device.poll(wgpu::PollType::wait_indefinitely());
     let result = if receiver.block_on().unwrap().is_ok() {
         let data = slice.get_mapped_range();
         let transformed_data = &*data;

--- a/bevy_gpu_compute/src/task/task_components/configuration/wgsl_code.rs
+++ b/bevy_gpu_compute/src/task/task_components/configuration/wgsl_code.rs
@@ -18,7 +18,7 @@ impl Default for WgslCode {
 }
 
 impl WgslCode {
-    pub fn from_string(
+    pub unsafe fn from_string(
         label: &str,
         render_device: &RenderDevice,
         wgsl_code: String,
@@ -33,7 +33,7 @@ impl WgslCode {
             })),
         }
     }
-    pub fn from_file(
+    pub unsafe fn from_file(
         label: &str,
         render_device: &RenderDevice,
         file_path: &str,

--- a/bevy_gpu_compute/src/task/task_components/configuration/wgsl_code.rs
+++ b/bevy_gpu_compute/src/task/task_components/configuration/wgsl_code.rs
@@ -27,10 +27,12 @@ impl WgslCode {
         Self {
             code: wgsl_code.clone(),
             entry_point_function_name,
-            shader_module: Some(render_device.create_shader_module(ShaderModuleDescriptor {
-                label: Some(label),
-                source: ShaderSource::Wgsl(wgsl_code.into()),
-            })),
+            shader_module: Some(unsafe {
+                render_device.create_shader_module(ShaderModuleDescriptor {
+                    label: Some(label),
+                    source: ShaderSource::Wgsl(wgsl_code.into()),
+                })
+            }),
         }
     }
     pub unsafe fn from_file(
@@ -40,7 +42,7 @@ impl WgslCode {
         entry_point_function_name: String,
     ) -> Self {
         let code = std::fs::read_to_string(file_path).unwrap();
-        Self::from_string(label, render_device, code, entry_point_function_name)
+        unsafe { Self::from_string(label, render_device, code, entry_point_function_name) }
     }
     pub fn code(&self) -> &str {
         &self.code

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2026-06-07"
+channel = "nightly"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2026-06-07"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
This PR upgrades `bevy` to the current latest version (`0.18`) and implements all the necessary migration changes. It also upgrades `wgpu` to `27`—in line with what Bevy 0.18 now uses.

# Changes
- Added `rust-toolchain.toml` which explicitly pins the required Rust toolchain version to nightly
## bevy_gpu_compute
- Use `despawn` instead of `despawn_recursive` and remove `DespawnRecursiveExt` trait imports ([0.15 → 0.16](https://bevy.org/learn/migration-guides/0-15-to-0-16/#use-new-relationship-system-for-parent-child-hierarchies))
- Use `IntoScheduleConfigs` trait instead of `IntoSystemConfigs` ([0.15 → 0.16](https://bevy.org/learn/migration-guides/0-15-to-0-16/#make-system-configuration-generic))
- Use `Projection::Orthographic(OrthographicProjection { /* ... */ })` instead of just `OrthographicProjection { /* ... */ }` in `spawn_fallback_camera` ([0.15 → 0.16](https://bevy.org/learn/migration-guides/0-15-to-0-16/#refactor-and-simplify-custom-projections)) 
- Mark `WgslCode::from_string` and `WgslCode::from_file` as unsafe since `RenderDevice::create_shader_module` is now marked as an unsafe function (0.15 → 0.16)
- Wrapped the `WgslCode::from_string` call within `BevyGpuComputeTask::from_shader` in an unsafe block and added `// SAFETY: wgsl_shader_module is compiled and validated`. This is sort of an assumption I made so if the maintainer could verify that that safety comment is correct that'd be great.
- When calling `RenderDevice::poll`, use `wgpu::PollType::wait_indefinitely()` instead of `wgpu::Maintain::Wait` ([wgpu 24 → 25](https://github.com/gfx-rs/wgpu/releases/tag/v25.0.0))

## bevy_gpu_compute/examples
- Use `MessageWriter` instead of the removed `EventWriter` ([0.16 → 0.17](https://bevy.org/learn/migration-guides/0-16-to-0-17/#event-trait-split-rename)) 
- Use `Projection::Orthographic(OrthographicProjection { /* ... */ })` instead of just `OrthographicProjection { /* ... */ }` ([0.15 → 0.16](https://bevy.org/learn/migration-guides/0-15-to-0-16/#refactor-and-simplify-custom-projections)) 